### PR TITLE
[Bug Fix] Actually pass the file encoding through to the parsing function from the class init.

### DIFF
--- a/valve_keyvalues_python/keyvalues.py
+++ b/valve_keyvalues_python/keyvalues.py
@@ -41,7 +41,7 @@ class KeyValues(dict):
             return
 
         if type(filename) == str:
-            self.parse(filename)
+            self.parse(filename, encoding=encoding)
         else:
             raise Exception("'filename' argument must be string!")
 


### PR DESCRIPTION

The value had previously just been ignored and the default UTF8 used. Some Source 1 games like TF2 use UTF-16 LE encoding and thus this needs to be passed through to readlines().